### PR TITLE
Fix logging file overflow

### DIFF
--- a/dbus-shelly-1pm-pvinverter.py
+++ b/dbus-shelly-1pm-pvinverter.py
@@ -3,6 +3,7 @@
 # import normal packages
 import platform
 import logging
+from logging.handlers import RotatingFileHandler
 import sys
 import os
 import sys
@@ -204,7 +205,7 @@ def main():
                             datefmt='%Y-%m-%d %H:%M:%S',
                             level=logging.INFO,
                             handlers=[
-                                logging.FileHandler("%s/current.log" % (os.path.dirname(os.path.realpath(__file__)))),
+                                RotatingFileHandler("%s/current.log" % (os.path.dirname(os.path.realpath(__file__))), 5*1024),
                                 logging.StreamHandler()
                             ])
 


### PR DESCRIPTION
Fix for https://github.com/vikt0rm/dbus-shelly-1pm-pvinverter/issues/4 by implementing a size limit for current.log